### PR TITLE
Use strict ISO 8601 for the date

### DIFF
--- a/src/__tests__/gatsby_node.js
+++ b/src/__tests__/gatsby_node.js
@@ -138,7 +138,7 @@ describe(`Processing File nodes matching filter regex`, () => {
     expect(createNodeField).toHaveBeenCalledWith({
       node,
       name: `gitLogLatestDate`,
-      value: `2018-08-20 20:19:19 +0000`,
+      value: `2018-08-20T20:19:19+00:00`,
     });
   });
 
@@ -161,7 +161,7 @@ describe(`Processing File nodes matching filter regex`, () => {
     expect(createNodeField).toHaveBeenCalledWith({
       node,
       name: `gitLogLatestDate`,
-      value: `2018-08-20 21:19:19 +0000`,
+      value: `2018-08-20T21:19:19+00:00`,
     });
   });
 
@@ -184,7 +184,7 @@ describe(`Processing File nodes matching filter regex`, () => {
     expect(createNodeField).toHaveBeenCalledWith({
       node,
       name: `gitLogLatestDate`,
-      value: `2018-08-20 21:19:19 +0000`,
+      value: `2018-08-20T21:19:19+00:00`,
     });
   });
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -22,7 +22,7 @@ async function getLogWithRetry(gitRepo, node, retry = 2) {
     file: filePath,
     n: 1,
     format: {
-      date: `%ai`,
+      date: `%aI`,
       authorName: `%an`,
       authorEmail: "%ae",
     },


### PR DESCRIPTION
Format the date value with strict ISO 8601 instead of git's ISO 8601-like format  to, to get any standard compliant to parse it.