### PR TITLE
chore: add Gatsby 5 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^3.0.0 || ^4.0.0"
+    "gatsby": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add Gatsby 5 peer dependency to make the plugin installable with Gatsby 5.